### PR TITLE
Standardize package naming from com.medscheduler.* to com.healthcare.…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 version = "0.1"
-group = "com.medscheduler"
+group = "com.healthcare.medication.scheduling"
 
 val kotlinVersion = project.properties.get("kotlinVersion")
 repositories {
@@ -51,7 +51,7 @@ dependencies {
 }
 
 application {
-    mainClass.set("com.medscheduler.ApplicationKt")
+    mainClass.set("com.healthcare.medication.scheduling.ApplicationKt")
 }
 
 java {

--- a/src/main/kotlin/com/healthcare/medication/scheduling/Application.kt
+++ b/src/main/kotlin/com/healthcare/medication/scheduling/Application.kt
@@ -1,4 +1,4 @@
-package com.medscheduler
+package com.healthcare.medication.scheduling
 
 import io.micronaut.runtime.Micronaut.run
 

--- a/src/main/kotlin/com/healthcare/medication/scheduling/config/DynamoDBConfig.kt
+++ b/src/main/kotlin/com/healthcare/medication/scheduling/config/DynamoDBConfig.kt
@@ -1,4 +1,4 @@
-package com.medscheduler.config
+package com.healthcare.medication.scheduling.config
 
 import io.micronaut.context.annotation.Bean
 import io.micronaut.context.annotation.Factory

--- a/src/main/kotlin/com/healthcare/medication/scheduling/controller/ScheduleController.kt
+++ b/src/main/kotlin/com/healthcare/medication/scheduling/controller/ScheduleController.kt
@@ -1,8 +1,8 @@
-package com.medscheduler.controller
+package com.healthcare.medication.scheduling.controller
 
-import com.medscheduler.model.Alert
-import com.medscheduler.model.Schedule
-import com.medscheduler.service.ScheduleService
+import com.healthcare.medication.scheduling.model.Alert
+import com.healthcare.medication.scheduling.model.Schedule
+import com.healthcare.medication.scheduling.service.ScheduleService
 import io.micronaut.http.annotation.*
 import kotlinx.datetime.LocalDate
 import java.util.*

--- a/src/main/kotlin/com/healthcare/medication/scheduling/model/Alert.kt
+++ b/src/main/kotlin/com/healthcare/medication/scheduling/model/Alert.kt
@@ -1,4 +1,4 @@
-package com.medscheduler.model
+package com.healthcare.medication.scheduling.model
 
 import io.micronaut.serde.annotation.Serdeable
 import kotlinx.datetime.Instant

--- a/src/main/kotlin/com/healthcare/medication/scheduling/model/Schedule.kt
+++ b/src/main/kotlin/com/healthcare/medication/scheduling/model/Schedule.kt
@@ -1,4 +1,4 @@
-package com.medscheduler.model
+package com.healthcare.medication.scheduling.model
 
 import io.micronaut.serde.annotation.Serdeable
 import kotlinx.datetime.Instant

--- a/src/main/kotlin/com/healthcare/medication/scheduling/repository/AlertRepository.kt
+++ b/src/main/kotlin/com/healthcare/medication/scheduling/repository/AlertRepository.kt
@@ -1,7 +1,7 @@
-package com.medscheduler.repository
+package com.healthcare.medication.scheduling.repository
 
-import com.medscheduler.model.Alert
-import com.medscheduler.model.AlertStatus
+import com.healthcare.medication.scheduling.model.Alert
+import com.healthcare.medication.scheduling.model.AlertStatus
 
 interface AlertRepository {
     suspend fun findById(alertId: String): Alert?

--- a/src/main/kotlin/com/healthcare/medication/scheduling/repository/ScheduleRepository.kt
+++ b/src/main/kotlin/com/healthcare/medication/scheduling/repository/ScheduleRepository.kt
@@ -1,6 +1,6 @@
-package com.medscheduler.repository
+package com.healthcare.medication.scheduling.repository
 
-import com.medscheduler.model.Schedule
+import com.healthcare.medication.scheduling.model.Schedule
 import kotlinx.datetime.LocalDate
 import java.util.*
 

--- a/src/main/kotlin/com/healthcare/medication/scheduling/service/AlertService.kt
+++ b/src/main/kotlin/com/healthcare/medication/scheduling/service/AlertService.kt
@@ -1,8 +1,8 @@
-package com.medscheduler.service
+package com.healthcare.medication.scheduling.service
 
-import com.medscheduler.model.Alert
-import com.medscheduler.model.AlertStatus
-import com.medscheduler.repository.AlertRepository
+import com.healthcare.medication.scheduling.model.Alert
+import com.healthcare.medication.scheduling.model.AlertStatus
+import com.healthcare.medication.scheduling.repository.AlertRepository
 import jakarta.inject.Singleton
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant

--- a/src/main/kotlin/com/healthcare/medication/scheduling/service/ScheduleService.kt
+++ b/src/main/kotlin/com/healthcare/medication/scheduling/service/ScheduleService.kt
@@ -1,8 +1,8 @@
-package com.medscheduler.service
+package com.healthcare.medication.scheduling.service
 
-import com.medscheduler.model.Alert
-import com.medscheduler.model.Schedule
-import com.medscheduler.repository.ScheduleRepository
+import com.healthcare.medication.scheduling.model.Alert
+import com.healthcare.medication.scheduling.model.Schedule
+import com.healthcare.medication.scheduling.repository.ScheduleRepository
 import io.micronaut.runtime.ApplicationConfiguration
 import jakarta.inject.Singleton
 import kotlinx.datetime.LocalDate

--- a/src/test/kotlin/com/healthcare/medication/scheduling/SimpleTest.kt
+++ b/src/test/kotlin/com/healthcare/medication/scheduling/SimpleTest.kt
@@ -1,4 +1,4 @@
-package com.medscheduler
+package com.healthcare.medication.scheduling
 
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.*


### PR DESCRIPTION
…medication.scheduling.*

- Refactored all Kotlin files from com.medscheduler.* to com.healthcare.medication.scheduling.*
- Updated package declarations across 10 files (controller, service, model, repository, config layers)
- Updated all import statements to reference new package structure
- Updated build.gradle.kts with new group and mainClass references
- Preserved exact same functionality - only package names changed
- All tests pass and service builds successfully

This resolves Critical Issue #1 from ISSUES.md for consistent package naming across all healthcare microservices.

🤖 Generated with [Claude Code](https://claude.ai/code)